### PR TITLE
Add callable source info

### DIFF
--- a/checker/tests/call_graph/fnptr.rs
+++ b/checker/tests/call_graph/fnptr.rs
@@ -68,22 +68,30 @@ commit;
     "tests/call_graph/fnptr.rs"
   ],
   "callables": [
-    [
-      "fnptr.fn1",
-      false
-    ],
-    [
-      "fnptr.fn2",
-      false
-    ],
-    [
-      "fnptr.fn3",
-      false
-    ],
-    [
-      "fnptr.main",
-      false
-    ]
+    {
+      "name": "fnptr.fn1",
+      "file_index": 0,
+      "first_line": 9,
+      "local": true
+    },
+    {
+      "name": "fnptr.fn2",
+      "file_index": 0,
+      "first_line": 12,
+      "local": true
+    },
+    {
+      "name": "fnptr.fn3",
+      "file_index": 0,
+      "first_line": 15,
+      "local": true
+    },
+    {
+      "name": "fnptr.main",
+      "file_index": 0,
+      "first_line": 18,
+      "local": true
+    }
   ],
   "calls": [
     [

--- a/checker/tests/call_graph/fnptr_clean.rs
+++ b/checker/tests/call_graph/fnptr_clean.rs
@@ -73,22 +73,30 @@ commit;
     "tests/call_graph/fnptr_clean.rs"
   ],
   "callables": [
-    [
-      "fnptr_clean.fn1",
-      false
-    ],
-    [
-      "fnptr_clean.fn2",
-      false
-    ],
-    [
-      "fnptr_clean.fn3",
-      false
-    ],
-    [
-      "fnptr_clean.main",
-      false
-    ]
+    {
+      "name": "fnptr_clean.fn1",
+      "file_index": 0,
+      "first_line": 14,
+      "local": true
+    },
+    {
+      "name": "fnptr_clean.fn2",
+      "file_index": 0,
+      "first_line": 17,
+      "local": true
+    },
+    {
+      "name": "fnptr_clean.fn3",
+      "file_index": 0,
+      "first_line": 20,
+      "local": true
+    },
+    {
+      "name": "fnptr_clean.main",
+      "file_index": 0,
+      "first_line": 23,
+      "local": true
+    }
   ],
   "calls": [
     [

--- a/checker/tests/call_graph/fnptr_deduplicate.rs
+++ b/checker/tests/call_graph/fnptr_deduplicate.rs
@@ -60,28 +60,35 @@ commit;
 }
 */
 
-/* EXPECTED:CALL_SITES
-{
+/* EXPECTED:CALL_SITES{
   "files": [
     "tests/call_graph/fnptr_deduplicate.rs"
   ],
   "callables": [
-    [
-      "fnptr_deduplicate.fn1",
-      false
-    ],
-    [
-      "fnptr_deduplicate.fn2",
-      false
-    ],
-    [
-      "fnptr_deduplicate.fn3",
-      false
-    ],
-    [
-      "fnptr_deduplicate.main",
-      false
-    ]
+    {
+      "name": "fnptr_deduplicate.fn1",
+      "file_index": 0,
+      "first_line": 10,
+      "local": true
+    },
+    {
+      "name": "fnptr_deduplicate.fn2",
+      "file_index": 0,
+      "first_line": 13,
+      "local": true
+    },
+    {
+      "name": "fnptr_deduplicate.fn3",
+      "file_index": 0,
+      "first_line": 16,
+      "local": true
+    },
+    {
+      "name": "fnptr_deduplicate.main",
+      "file_index": 0,
+      "first_line": 19,
+      "local": true
+    }
   ],
   "calls": [
     [
@@ -106,5 +113,4 @@ commit;
       0
     ]
   ]
-}
-*/
+}*/

--- a/checker/tests/call_graph/fnptr_dom.rs
+++ b/checker/tests/call_graph/fnptr_dom.rs
@@ -70,22 +70,30 @@ commit;
     "tests/call_graph/fnptr_dom.rs"
   ],
   "callables": [
-    [
-      "fnptr_dom.fn1",
-      false
-    ],
-    [
-      "fnptr_dom.fn2",
-      false
-    ],
-    [
-      "fnptr_dom.fn3",
-      false
-    ],
-    [
-      "fnptr_dom.main",
-      false
-    ]
+    {
+      "name": "fnptr_dom.fn1",
+      "file_index": 0,
+      "first_line": 9,
+      "local": true
+    },
+    {
+      "name": "fnptr_dom.fn2",
+      "file_index": 0,
+      "first_line": 13,
+      "local": true
+    },
+    {
+      "name": "fnptr_dom.fn3",
+      "file_index": 0,
+      "first_line": 16,
+      "local": true
+    },
+    {
+      "name": "fnptr_dom.main",
+      "file_index": 0,
+      "first_line": 19,
+      "local": true
+    }
   ],
   "calls": [
     [

--- a/checker/tests/call_graph/fnptr_dom_loop.rs
+++ b/checker/tests/call_graph/fnptr_dom_loop.rs
@@ -84,26 +84,36 @@ commit;
     "tests/call_graph/fnptr_dom_loop.rs"
   ],
   "callables": [
-    [
-      "fnptr_dom_loop.fn1",
-      false
-    ],
-    [
-      "fnptr_dom_loop.fn2",
-      false
-    ],
-    [
-      "fnptr_dom_loop.fn3",
-      false
-    ],
-    [
-      "fnptr_dom_loop.fn4",
-      false
-    ],
-    [
-      "fnptr_dom_loop.main",
-      false
-    ]
+    {
+      "name": "fnptr_dom_loop.fn1",
+      "file_index": 0,
+      "first_line": 9,
+      "local": true
+    },
+    {
+      "name": "fnptr_dom_loop.fn2",
+      "file_index": 0,
+      "first_line": 13,
+      "local": true
+    },
+    {
+      "name": "fnptr_dom_loop.fn3",
+      "file_index": 0,
+      "first_line": 16,
+      "local": true
+    },
+    {
+      "name": "fnptr_dom_loop.fn4",
+      "file_index": 0,
+      "first_line": 19,
+      "local": true
+    },
+    {
+      "name": "fnptr_dom_loop.main",
+      "file_index": 0,
+      "first_line": 26,
+      "local": true
+    }
   ],
   "calls": [
     [

--- a/checker/tests/call_graph/fnptr_dom_loop_souffle.rs
+++ b/checker/tests/call_graph/fnptr_dom_loop_souffle.rs
@@ -81,26 +81,36 @@ digraph {
     "tests/call_graph/fnptr_dom_loop_souffle.rs"
   ],
   "callables": [
-    [
-      "fnptr_dom_loop_souffle.fn1",
-      false
-    ],
-    [
-      "fnptr_dom_loop_souffle.fn2",
-      false
-    ],
-    [
-      "fnptr_dom_loop_souffle.fn3",
-      false
-    ],
-    [
-      "fnptr_dom_loop_souffle.fn4",
-      false
-    ],
-    [
-      "fnptr_dom_loop_souffle.main",
-      false
-    ]
+    {
+      "name": "fnptr_dom_loop_souffle.fn1",
+      "file_index": 0,
+      "first_line": 10,
+      "local": true
+    },
+    {
+      "name": "fnptr_dom_loop_souffle.fn2",
+      "file_index": 0,
+      "first_line": 14,
+      "local": true
+    },
+    {
+      "name": "fnptr_dom_loop_souffle.fn3",
+      "file_index": 0,
+      "first_line": 17,
+      "local": true
+    },
+    {
+      "name": "fnptr_dom_loop_souffle.fn4",
+      "file_index": 0,
+      "first_line": 20,
+      "local": true
+    },
+    {
+      "name": "fnptr_dom_loop_souffle.main",
+      "file_index": 0,
+      "first_line": 27,
+      "local": true
+    }
   ],
   "calls": [
     [

--- a/checker/tests/call_graph/fnptr_fold.rs
+++ b/checker/tests/call_graph/fnptr_fold.rs
@@ -68,33 +68,46 @@ commit;
 /* EXPECTED:CALL_SITES{
   "files": [
     "tests/call_graph/fnptr_fold.rs",
+    "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/std/src/io/stdio.rs",
     "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/core/src/fmt/mod.rs"
   ],
   "callables": [
-    [
-      "fnptr_fold.fn1",
-      false
-    ],
-    [
-      "fnptr_fold.fn2",
-      false
-    ],
-    [
-      "fnptr_fold.fn3",
-      false
-    ],
-    [
-      "fnptr_fold.main",
-      false
-    ],
-    [
-      "std.io.stdio._print",
-      true
-    ],
-    [
-      "core.fmt.implement_core_fmt_Arguments.new_v1",
-      false
-    ]
+    {
+      "name": "fnptr_fold.fn1",
+      "file_index": 0,
+      "first_line": 10,
+      "local": true
+    },
+    {
+      "name": "fnptr_fold.fn2",
+      "file_index": 0,
+      "first_line": 13,
+      "local": true
+    },
+    {
+      "name": "fnptr_fold.fn3",
+      "file_index": 0,
+      "first_line": 16,
+      "local": true
+    },
+    {
+      "name": "fnptr_fold.main",
+      "file_index": 0,
+      "first_line": 20,
+      "local": true
+    },
+    {
+      "name": "std.io.stdio._print",
+      "file_index": 1,
+      "first_line": 1027,
+      "local": false
+    },
+    {
+      "name": "core.fmt.implement_core_fmt_Arguments.new_v1",
+      "file_index": 2,
+      "first_line": 388,
+      "local": true
+    }
   ],
   "calls": [
     [
@@ -133,7 +146,7 @@ commit;
       5
     ],
     [
-      1,
+      2,
       390,
       13,
       5,

--- a/checker/tests/call_graph/fnptr_loop.rs
+++ b/checker/tests/call_graph/fnptr_loop.rs
@@ -75,22 +75,30 @@ commit;
     "tests/call_graph/fnptr_loop.rs"
   ],
   "callables": [
-    [
-      "fnptr_loop.fn1",
-      false
-    ],
-    [
-      "fnptr_loop.fn2",
-      false
-    ],
-    [
-      "fnptr_loop.fn3",
-      false
-    ],
-    [
-      "fnptr_loop.main",
-      false
-    ]
+    {
+      "name": "fnptr_loop.fn1",
+      "file_index": 0,
+      "first_line": 9,
+      "local": true
+    },
+    {
+      "name": "fnptr_loop.fn2",
+      "file_index": 0,
+      "first_line": 12,
+      "local": true
+    },
+    {
+      "name": "fnptr_loop.fn3",
+      "file_index": 0,
+      "first_line": 15,
+      "local": true
+    },
+    {
+      "name": "fnptr_loop.main",
+      "file_index": 0,
+      "first_line": 22,
+      "local": true
+    }
   ],
   "calls": [
     [

--- a/checker/tests/call_graph/fnptr_slice.rs
+++ b/checker/tests/call_graph/fnptr_slice.rs
@@ -61,22 +61,30 @@ commit;
     "tests/call_graph/fnptr_slice.rs"
   ],
   "callables": [
-    [
-      "fnptr_slice.fn1",
-      false
-    ],
-    [
-      "fnptr_slice.fn2",
-      false
-    ],
-    [
-      "fnptr_slice.fn3",
-      false
-    ],
-    [
-      "fnptr_slice.main",
-      false
-    ]
+    {
+      "name": "fnptr_slice.fn1",
+      "file_index": 0,
+      "first_line": 10,
+      "local": true
+    },
+    {
+      "name": "fnptr_slice.fn2",
+      "file_index": 0,
+      "first_line": 13,
+      "local": true
+    },
+    {
+      "name": "fnptr_slice.fn3",
+      "file_index": 0,
+      "first_line": 16,
+      "local": true
+    },
+    {
+      "name": "fnptr_slice.main",
+      "file_index": 0,
+      "first_line": 19,
+      "local": true
+    }
   ],
   "calls": [
     [

--- a/checker/tests/call_graph/replace_croot.rs
+++ b/checker/tests/call_graph/replace_croot.rs
@@ -46,20 +46,23 @@ commit;
 }
 */
 
-/* EXPECTED:CALL_SITES
-{
+/* EXPECTED:CALL_SITES{
   "files": [
     "tests/call_graph/replace_croot.rs"
   ],
   "callables": [
-    [
-      "replace_croot.main",
-      false
-    ],
-    [
-      "replace_croot.fn1",
-      false
-    ]
+    {
+      "name": "replace_croot.main",
+      "file_index": 0,
+      "first_line": 10,
+      "local": true
+    },
+    {
+      "name": "replace_croot.fn1",
+      "file_index": 0,
+      "first_line": 14,
+      "local": true
+    }
   ],
   "calls": [
     [
@@ -70,5 +73,4 @@ commit;
       1
     ]
   ]
-}
-*/
+}*/

--- a/checker/tests/call_graph/static.rs
+++ b/checker/tests/call_graph/static.rs
@@ -64,22 +64,30 @@ commit;
     "tests/call_graph/static.rs"
   ],
   "callables": [
-    [
-      "static.fn1",
-      false
-    ],
-    [
-      "static.fn2",
-      false
-    ],
-    [
-      "static.fn3",
-      false
-    ],
-    [
-      "static.main",
-      false
-    ]
+    {
+      "name": "static.fn1",
+      "file_index": 0,
+      "first_line": 9,
+      "local": true
+    },
+    {
+      "name": "static.fn2",
+      "file_index": 0,
+      "first_line": 12,
+      "local": true
+    },
+    {
+      "name": "static.fn3",
+      "file_index": 0,
+      "first_line": 15,
+      "local": true
+    },
+    {
+      "name": "static.main",
+      "file_index": 0,
+      "first_line": 18,
+      "local": true
+    }
   ],
   "calls": [
     [

--- a/checker/tests/call_graph/static_clean.rs
+++ b/checker/tests/call_graph/static_clean.rs
@@ -69,22 +69,30 @@ commit;
     "tests/call_graph/static_clean.rs"
   ],
   "callables": [
-    [
-      "static_clean.fn1",
-      false
-    ],
-    [
-      "static_clean.fn2",
-      false
-    ],
-    [
-      "static_clean.fn3",
-      false
-    ],
-    [
-      "static_clean.main",
-      false
-    ]
+    {
+      "name": "static_clean.fn1",
+      "file_index": 0,
+      "first_line": 14,
+      "local": true
+    },
+    {
+      "name": "static_clean.fn2",
+      "file_index": 0,
+      "first_line": 17,
+      "local": true
+    },
+    {
+      "name": "static_clean.fn3",
+      "file_index": 0,
+      "first_line": 20,
+      "local": true
+    },
+    {
+      "name": "static_clean.main",
+      "file_index": 0,
+      "first_line": 23,
+      "local": true
+    }
   ],
   "calls": [
     [

--- a/checker/tests/call_graph/static_deduplicate.rs
+++ b/checker/tests/call_graph/static_deduplicate.rs
@@ -65,22 +65,30 @@ commit;
     "tests/call_graph/static_deduplicate.rs"
   ],
   "callables": [
-    [
-      "static_deduplicate.fn1",
-      false
-    ],
-    [
-      "static_deduplicate.fn2",
-      false
-    ],
-    [
-      "static_deduplicate.fn3",
-      false
-    ],
-    [
-      "static_deduplicate.main",
-      false
-    ]
+    {
+      "name": "static_deduplicate.fn1",
+      "file_index": 0,
+      "first_line": 10,
+      "local": true
+    },
+    {
+      "name": "static_deduplicate.fn2",
+      "file_index": 0,
+      "first_line": 13,
+      "local": true
+    },
+    {
+      "name": "static_deduplicate.fn3",
+      "file_index": 0,
+      "first_line": 16,
+      "local": true
+    },
+    {
+      "name": "static_deduplicate.main",
+      "file_index": 0,
+      "first_line": 19,
+      "local": true
+    }
   ],
   "calls": [
     [

--- a/checker/tests/call_graph/static_dom.rs
+++ b/checker/tests/call_graph/static_dom.rs
@@ -64,51 +64,57 @@ commit;
 }
 */
 
-/* EXPECTED:CALL_SITES
-{
+/* EXPECTED:CALL_SITES{
   "files": [
     "tests/call_graph/static_dom.rs"
   ],
   "callables": [
-    [
-      "static_dom.main",
-      false
-    ],
-    [
-      "static_dom.fn2",
-      false
-    ],
-    [
-      "static_dom.fn3",
-      false
-    ],
-    [
-      "static_dom.fn1",
-      false
-    ]
+    {
+      "name": "static_dom.main",
+      "file_index": 0,
+      "first_line": 18,
+      "local": true
+    },
+    {
+      "name": "static_dom.fn1",
+      "file_index": 0,
+      "first_line": 9,
+      "local": true
+    },
+    {
+      "name": "static_dom.fn2",
+      "file_index": 0,
+      "first_line": 12,
+      "local": true
+    },
+    {
+      "name": "static_dom.fn3",
+      "file_index": 0,
+      "first_line": 15,
+      "local": true
+    }
   ],
   "calls": [
     [
       0,
-      21,
+      20,
       13,
       0,
       1
     ],
     [
       0,
-      22,
-      5,
+      21,
+      13,
       0,
       2
     ],
     [
       0,
-      20,
-      13,
+      22,
+      5,
       0,
       3
     ]
   ]
-}
-*/
+}*/

--- a/checker/tests/call_graph/static_dom_loop.rs
+++ b/checker/tests/call_graph/static_dom_loop.rs
@@ -80,26 +80,36 @@ commit;
     "tests/call_graph/static_dom_loop.rs"
   ],
   "callables": [
-    [
-      "static_dom_loop.fn1",
-      false
-    ],
-    [
-      "static_dom_loop.fn2",
-      false
-    ],
-    [
-      "static_dom_loop.fn3",
-      false
-    ],
-    [
-      "static_dom_loop.fn4",
-      false
-    ],
-    [
-      "static_dom_loop.main",
-      false
-    ]
+    {
+      "name": "static_dom_loop.fn1",
+      "file_index": 0,
+      "first_line": 9,
+      "local": true
+    },
+    {
+      "name": "static_dom_loop.fn2",
+      "file_index": 0,
+      "first_line": 13,
+      "local": true
+    },
+    {
+      "name": "static_dom_loop.fn3",
+      "file_index": 0,
+      "first_line": 16,
+      "local": true
+    },
+    {
+      "name": "static_dom_loop.fn4",
+      "file_index": 0,
+      "first_line": 19,
+      "local": true
+    },
+    {
+      "name": "static_dom_loop.main",
+      "file_index": 0,
+      "first_line": 26,
+      "local": true
+    }
   ],
   "calls": [
     [

--- a/checker/tests/call_graph/static_fold.rs
+++ b/checker/tests/call_graph/static_fold.rs
@@ -64,33 +64,46 @@ commit;
 /* EXPECTED:CALL_SITES{
   "files": [
     "tests/call_graph/static_fold.rs",
+    "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/std/src/io/stdio.rs",
     "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/core/src/fmt/mod.rs"
   ],
   "callables": [
-    [
-      "static_fold.fn1",
-      false
-    ],
-    [
-      "static_fold.fn2",
-      false
-    ],
-    [
-      "static_fold.fn3",
-      false
-    ],
-    [
-      "static_fold.main",
-      false
-    ],
-    [
-      "std.io.stdio._print",
-      true
-    ],
-    [
-      "core.fmt.implement_core_fmt_Arguments.new_v1",
-      false
-    ]
+    {
+      "name": "static_fold.fn1",
+      "file_index": 0,
+      "first_line": 10,
+      "local": true
+    },
+    {
+      "name": "static_fold.fn2",
+      "file_index": 0,
+      "first_line": 13,
+      "local": true
+    },
+    {
+      "name": "static_fold.fn3",
+      "file_index": 0,
+      "first_line": 16,
+      "local": true
+    },
+    {
+      "name": "static_fold.main",
+      "file_index": 0,
+      "first_line": 20,
+      "local": true
+    },
+    {
+      "name": "std.io.stdio._print",
+      "file_index": 1,
+      "first_line": 1027,
+      "local": false
+    },
+    {
+      "name": "core.fmt.implement_core_fmt_Arguments.new_v1",
+      "file_index": 2,
+      "first_line": 388,
+      "local": true
+    }
   ],
   "calls": [
     [
@@ -129,7 +142,7 @@ commit;
       5
     ],
     [
-      1,
+      2,
       390,
       13,
       5,

--- a/checker/tests/call_graph/static_loop.rs
+++ b/checker/tests/call_graph/static_loop.rs
@@ -71,22 +71,30 @@ commit;
     "tests/call_graph/static_loop.rs"
   ],
   "callables": [
-    [
-      "static_loop.fn1",
-      false
-    ],
-    [
-      "static_loop.fn2",
-      false
-    ],
-    [
-      "static_loop.fn3",
-      false
-    ],
-    [
-      "static_loop.main",
-      false
-    ]
+    {
+      "name": "static_loop.fn1",
+      "file_index": 0,
+      "first_line": 9,
+      "local": true
+    },
+    {
+      "name": "static_loop.fn2",
+      "file_index": 0,
+      "first_line": 12,
+      "local": true
+    },
+    {
+      "name": "static_loop.fn3",
+      "file_index": 0,
+      "first_line": 15,
+      "local": true
+    },
+    {
+      "name": "static_loop.main",
+      "file_index": 0,
+      "first_line": 22,
+      "local": true
+    }
   ],
   "calls": [
     [

--- a/checker/tests/call_graph/static_no_args.rs
+++ b/checker/tests/call_graph/static_no_args.rs
@@ -45,20 +45,23 @@ commit;
 }
 */
 
-/* EXPECTED:CALL_SITES
-{
+/* EXPECTED:CALL_SITES{
   "files": [
     "tests/call_graph/static_no_args.rs"
   ],
   "callables": [
-    [
-      "static_no_args.main",
-      false
-    ],
-    [
-      "static_no_args.fn1",
-      false
-    ]
+    {
+      "name": "static_no_args.main",
+      "file_index": 0,
+      "first_line": 13,
+      "local": true
+    },
+    {
+      "name": "static_no_args.fn1",
+      "file_index": 0,
+      "first_line": 10,
+      "local": true
+    }
   ],
   "calls": [
     [
@@ -69,5 +72,4 @@ commit;
       1
     ]
   ]
-}
-*/
+}*/

--- a/checker/tests/call_graph/static_slice.rs
+++ b/checker/tests/call_graph/static_slice.rs
@@ -61,22 +61,30 @@ commit;
     "tests/call_graph/static_slice.rs"
   ],
   "callables": [
-    [
-      "static_slice.fn1",
-      false
-    ],
-    [
-      "static_slice.fn2",
-      false
-    ],
-    [
-      "static_slice.fn3",
-      false
-    ],
-    [
-      "static_slice.main",
-      false
-    ]
+    {
+      "name": "static_slice.fn1",
+      "file_index": 0,
+      "first_line": 10,
+      "local": true
+    },
+    {
+      "name": "static_slice.fn2",
+      "file_index": 0,
+      "first_line": 13,
+      "local": true
+    },
+    {
+      "name": "static_slice.fn3",
+      "file_index": 0,
+      "first_line": 16,
+      "local": true
+    },
+    {
+      "name": "static_slice.main",
+      "file_index": 0,
+      "first_line": 19,
+      "local": true
+    }
   ],
   "calls": [
     [

--- a/checker/tests/call_graph/static_souffle.rs
+++ b/checker/tests/call_graph/static_souffle.rs
@@ -62,22 +62,30 @@ digraph {
     "tests/call_graph/static_souffle.rs"
   ],
   "callables": [
-    [
-      "static_souffle.fn1",
-      false
-    ],
-    [
-      "static_souffle.fn2",
-      false
-    ],
-    [
-      "static_souffle.fn3",
-      false
-    ],
-    [
-      "static_souffle.main",
-      false
-    ]
+    {
+      "name": "static_souffle.fn1",
+      "file_index": 0,
+      "first_line": 10,
+      "local": true
+    },
+    {
+      "name": "static_souffle.fn2",
+      "file_index": 0,
+      "first_line": 13,
+      "local": true
+    },
+    {
+      "name": "static_souffle.fn3",
+      "file_index": 0,
+      "first_line": 16,
+      "local": true
+    },
+    {
+      "name": "static_souffle.main",
+      "file_index": 0,
+      "first_line": 19,
+      "local": true
+    }
   ],
   "calls": [
     [

--- a/checker/tests/call_graph/type_relations.rs
+++ b/checker/tests/call_graph/type_relations.rs
@@ -122,361 +122,535 @@ commit;
 }
 */
 
-/* EXPECTED:CALL_SITES
-{
+/* EXPECTED:CALL_SITES{
   "files": [
     "tests/call_graph/type_relations.rs",
+    "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/core/src/fmt/builders.rs",
+    "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/core/src/fmt/mod.rs",
+    "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/core/src/slice/mod.rs",
+    "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/core/src/slice/iter/macros.rs",
+    "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/alloc/src/vec/mod.rs",
+    "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/std/src/io/stdio.rs",
     "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/core/src/mem/valid_align.rs",
+    "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/core/src/num/nonzero.rs",
     "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/core/src/ptr/mod.rs",
-    "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/core/src/ptr/non_null.rs",
-    "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/core/src/ptr/unique.rs",
+    "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/core/src/ptr/metadata.rs",
     "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/core/src/ptr/const_ptr.rs",
     "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/core/src/ptr/mut_ptr.rs",
-    "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/core/src/fmt/mod.rs",
+    "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/core/src/ptr/non_null.rs",
+    "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/core/src/ptr/unique.rs",
+    "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/core/src/intrinsics.rs",
     "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/core/src/result.rs",
-    "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/core/src/slice/mod.rs",
+    "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/core/src/convert/mod.rs",
     "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/core/src/slice/iter.rs",
+    "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/core/src/mem/mod.rs",
     "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/core/src/slice/raw.rs",
     "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/core/src/alloc/layout.rs",
-    "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/alloc/src/raw_vec.rs",
-    "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/alloc/src/alloc.rs",
-    "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/alloc/src/boxed.rs",
     "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/alloc/src/slice.rs",
-    "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/alloc/src/vec/mod.rs"
+    "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/alloc/src/alloc.rs",
+    "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/alloc/src/raw_vec.rs",
+    "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/alloc/src/boxed.rs",
+    "/rustc/4c5f6e6277b89e47d73a192078697f7a5f3dc0ac/library/core/src/mem/manually_drop.rs"
   ],
   "callables": [
-    [
-      "type_relations.implement.fmt",
-      false
-    ],
-    [
-      "core.fmt.builders.implement_core_fmt_builders_DebugStruct.finish",
-      true
-    ],
-    [
-      "type_relations.foo_ref",
-      false
-    ],
-    [
-      "core.fmt.implement_core_fmt_ArgumentV1.new_display",
-      false
-    ],
-    [
-      "type_relations.foo_mut_ref",
-      false
-    ],
-    [
-      "type_relations.foo_slice_iter",
-      false
-    ],
-    [
-      "core.slice.implement.iter",
-      false
-    ],
-    [
-      "core.slice.iter.implement_core_slice_iter_Iter_generic_par_T.next",
-      false
-    ],
-    [
-      "type_relations.foo_vec_iter",
-      false
-    ],
-    [
-      "alloc.vec.implement_alloc_vec_Vec_generic_par_T_generic_par_A.drop",
-      false
-    ],
-    [
-      "type_relations.main",
-      false
-    ],
-    [
-      "alloc.vec.implement_alloc_vec_Vec_generic_par_T_generic_par_A.deref",
-      false
-    ],
-    [
-      "std.io.stdio._print",
-      true
-    ],
-    [
-      "core.fmt.implement_core_fmt_Arguments.new_v1",
-      false
-    ],
-    [
-      "core.mem.valid_align.implement.as_nonzero",
-      false
-    ],
-    [
-      "core.num.nonzero.implement_core_num_nonzero_NonZeroUsize.new_unchecked",
-      true
-    ],
-    [
-      "core.ptr.null",
-      false
-    ],
-    [
-      "core.ptr.invalid",
-      false
-    ],
-    [
-      "core.ptr.null_mut",
-      false
-    ],
-    [
-      "core.ptr.invalid_mut",
-      false
-    ],
-    [
-      "core.ptr.slice_from_raw_parts",
-      false
-    ],
-    [
-      "core.ptr.metadata.from_raw_parts",
-      false
-    ],
-    [
-      "core.ptr.const_ptr.implement.cast",
-      false
-    ],
-    [
-      "core.ptr.slice_from_raw_parts_mut",
-      false
-    ],
-    [
-      "core.ptr.metadata.from_raw_parts_mut",
-      false
-    ],
-    [
-      "core.ptr.mut_ptr.implement.cast",
-      false
-    ],
-    [
-      "core.ptr.non_null.implement_core_ptr_non_null_NonNull_generic_par_T.new",
-      false
-    ],
-    [
-      "core.ptr.mut_ptr.implement.is_null",
-      false
-    ],
-    [
-      "core.ptr.non_null.implement_core_ptr_non_null_NonNull_generic_par_T.new_unchecked",
-      false
-    ],
-    [
-      "core.ptr.non_null.implement_core_ptr_non_null_NonNull_slice_generic_par_T.slice_from_raw_parts",
-      false
-    ],
-    [
-      "core.ptr.non_null.implement_core_ptr_non_null_NonNull_generic_par_T.as_ptr",
-      false
-    ],
-    [
-      "core.ptr.non_null.implement_core_ptr_non_null_NonNull_slice_generic_par_T.as_non_null_ptr",
-      false
-    ],
-    [
-      "core.ptr.mut_ptr.implement_pointer_mut_slice_generic_par_T.as_mut_ptr",
-      false
-    ],
-    [
-      "core.ptr.non_null.implement_core_ptr_non_null_NonNull_slice_generic_par_T.as_mut_ptr",
-      false
-    ],
-    [
-      "core.ptr.unique.implement_core_ptr_unique_Unique_generic_par_T.new_unchecked",
-      false
-    ],
-    [
-      "core.ptr.unique.implement_core_ptr_unique_Unique_generic_par_T.as_ptr",
-      false
-    ],
-    [
-      "core.ptr.unique.implement_core_ptr_unique_Unique_generic_par_T.from",
-      false
-    ],
-    [
-      "core.ptr.unique.implement_core_ptr_unique_Unique_generic_par_T.from",
-      false
-    ],
-    [
-      "core.ptr.non_null.implement_core_ptr_non_null_NonNull_generic_par_T.from",
-      false
-    ],
-    [
-      "core.ptr.const_ptr.implement.is_null",
-      false
-    ],
-    [
-      "core.ptr.const_ptr.implement.guaranteed_eq",
-      false
-    ],
-    [
-      "core.intrinsics.foreign_1.ptr_guaranteed_eq",
-      true
-    ],
-    [
-      "core.ptr.const_ptr.implement.add",
-      false
-    ],
-    [
-      "core.ptr.const_ptr.implement.offset",
-      false
-    ],
-    [
-      "core.ptr.const_ptr.implement.wrapping_add",
-      false
-    ],
-    [
-      "core.ptr.const_ptr.implement.wrapping_offset",
-      false
-    ],
-    [
-      "core.ptr.mut_ptr.implement.guaranteed_eq",
-      false
-    ],
-    [
-      "core.result.implement_core_result_Result_generic_par_T_generic_par_F.from_residual",
-      false
-    ],
-    [
-      "core.convert.implement_generic_par_T.from",
-      false
-    ],
-    [
-      "core.fmt.implement_core_fmt_ArgumentV1.new",
-      false
-    ],
-    [
-      "core.slice.iter.implement_core_slice_iter_Iter_generic_par_T.new",
-      false
-    ],
-    [
-      "core.slice.implement.as_ptr",
-      false
-    ],
-    [
-      "core.intrinsics.foreign_1.assume",
-      true
-    ],
-    [
-      "core.mem.size_of",
-      false
-    ],
-    [
-      "core.slice.iter.implement_core_slice_iter_Iter_generic_par_T.post_inc_start",
-      false
-    ],
-    [
-      "core.ptr.mut_ptr.implement.offset",
-      false
-    ],
-    [
-      "core.slice.raw.from_raw_parts",
-      false
-    ],
-    [
-      "core.alloc.layout.implement.from_size_align_unchecked",
-      false
-    ],
-    [
-      "core.mem.valid_align.implement.new_unchecked",
-      true
-    ],
-    [
-      "core.alloc.layout.implement.dangling",
-      false
-    ],
-    [
-      "core.alloc.layout.implement.align",
-      true
-    ],
-    [
-      "alloc.slice.implement.into_vec",
-      false
-    ],
-    [
-      "alloc.alloc.exchange_malloc",
-      true
-    ],
-    [
-      "alloc.raw_vec.implement_alloc_raw_vec_RawVec_generic_par_T_generic_par_A.from_raw_parts_in",
-      false
-    ],
-    [
-      "alloc.raw_vec.implement_alloc_raw_vec_RawVec_generic_par_T_generic_par_A.ptr",
-      false
-    ],
-    [
-      "alloc.alloc.alloc",
-      false
-    ],
-    [
-      "core.alloc.layout.implement.size",
-      true
-    ],
-    [
-      "alloc.alloc.alloc_zeroed",
-      false
-    ],
-    [
-      "alloc.alloc.implement_alloc_alloc_Global.allocate",
-      false
-    ],
-    [
-      "alloc.alloc.implement.alloc_impl",
-      true
-    ],
-    [
-      "alloc.boxed.implement_alloc_boxed_Box_generic_par_T_generic_par_A.into_raw_with_allocator",
-      false
-    ],
-    [
-      "alloc.boxed.implement_alloc_boxed_Box_generic_par_T_generic_par_A.into_unique",
-      false
-    ],
-    [
-      "core.ptr.read",
-      false
-    ],
-    [
-      "alloc.boxed.implement_alloc_boxed_Box_generic_par_T_generic_par_A.leak",
-      false
-    ],
-    [
-      "alloc.boxed.implement_alloc_boxed_Box_generic_par_T_generic_par_A.drop",
-      false
-    ],
-    [
-      "core.mem.manually_drop.implement.new",
-      false
-    ],
-    [
-      "core.mem.manually_drop.implement_core_mem_manually_drop_ManuallyDrop_generic_par_T.deref",
-      false
-    ],
-    [
-      "alloc.slice.hack.into_vec",
-      false
-    ],
-    [
-      "core.slice.implement.len",
-      false
-    ],
-    [
-      "alloc.vec.implement_alloc_vec_Vec_generic_par_T_generic_par_A.from_raw_parts_in",
-      false
-    ],
-    [
-      "alloc.vec.implement_alloc_vec_Vec_generic_par_T_generic_par_A.as_ptr",
-      false
-    ],
-    [
-      "alloc.vec.implement_alloc_vec_Vec_generic_par_T_generic_par_A.as_mut_ptr",
-      false
-    ],
-    [
-      "core.ptr.drop_in_place",
-      false
-    ]
+    {
+      "name": "type_relations.implement.fmt",
+      "file_index": 0,
+      "first_line": 8,
+      "local": true
+    },
+    {
+      "name": "core.fmt.builders.implement_core_fmt_builders_DebugStruct.finish",
+      "file_index": 1,
+      "first_line": 233,
+      "local": false
+    },
+    {
+      "name": "type_relations.foo_ref",
+      "file_index": 0,
+      "first_line": 13,
+      "local": true
+    },
+    {
+      "name": "core.fmt.implement_core_fmt_ArgumentV1.new_display",
+      "file_index": 2,
+      "first_line": 317,
+      "local": true
+    },
+    {
+      "name": "type_relations.foo_mut_ref",
+      "file_index": 0,
+      "first_line": 17,
+      "local": true
+    },
+    {
+      "name": "type_relations.foo_slice_iter",
+      "file_index": 0,
+      "first_line": 22,
+      "local": true
+    },
+    {
+      "name": "core.slice.implement.iter",
+      "file_index": 3,
+      "first_line": 732,
+      "local": true
+    },
+    {
+      "name": "core.slice.iter.implement_core_slice_iter_Iter_generic_par_T.next",
+      "file_index": 4,
+      "first_line": 134,
+      "local": true
+    },
+    {
+      "name": "type_relations.foo_vec_iter",
+      "file_index": 0,
+      "first_line": 28,
+      "local": true
+    },
+    {
+      "name": "alloc.vec.implement_alloc_vec_Vec_generic_par_T_generic_par_A.drop",
+      "file_index": 5,
+      "first_line": 2876,
+      "local": true
+    },
+    {
+      "name": "type_relations.main",
+      "file_index": 0,
+      "first_line": 34,
+      "local": true
+    },
+    {
+      "name": "alloc.vec.implement_alloc_vec_Vec_generic_par_T_generic_par_A.deref",
+      "file_index": 5,
+      "first_line": 2496,
+      "local": true
+    },
+    {
+      "name": "std.io.stdio._print",
+      "file_index": 6,
+      "first_line": 1027,
+      "local": false
+    },
+    {
+      "name": "core.fmt.implement_core_fmt_Arguments.new_v1",
+      "file_index": 2,
+      "first_line": 388,
+      "local": true
+    },
+    {
+      "name": "core.mem.valid_align.implement.as_nonzero",
+      "file_index": 7,
+      "first_line": 37,
+      "local": true
+    },
+    {
+      "name": "core.num.nonzero.implement_core_num_nonzero_NonZeroUsize.new_unchecked",
+      "file_index": 8,
+      "first_line": 55,
+      "local": false
+    },
+    {
+      "name": "core.ptr.null",
+      "file_index": 9,
+      "first_line": 510,
+      "local": true
+    },
+    {
+      "name": "core.ptr.invalid",
+      "file_index": 9,
+      "first_line": 556,
+      "local": true
+    },
+    {
+      "name": "core.ptr.null_mut",
+      "file_index": 9,
+      "first_line": 530,
+      "local": true
+    },
+    {
+      "name": "core.ptr.invalid_mut",
+      "file_index": 9,
+      "first_line": 583,
+      "local": true
+    },
+    {
+      "name": "core.ptr.slice_from_raw_parts",
+      "file_index": 9,
+      "first_line": 683,
+      "local": true
+    },
+    {
+      "name": "core.ptr.metadata.from_raw_parts",
+      "file_index": 10,
+      "first_line": 110,
+      "local": true
+    },
+    {
+      "name": "core.ptr.const_ptr.implement.cast",
+      "file_index": 11,
+      "first_line": 46,
+      "local": true
+    },
+    {
+      "name": "core.ptr.slice_from_raw_parts_mut",
+      "file_index": 9,
+      "first_line": 715,
+      "local": true
+    },
+    {
+      "name": "core.ptr.metadata.from_raw_parts_mut",
+      "file_index": 10,
+      "first_line": 127,
+      "local": true
+    },
+    {
+      "name": "core.ptr.mut_ptr.implement.cast",
+      "file_index": 12,
+      "first_line": 45,
+      "local": true
+    },
+    {
+      "name": "core.ptr.non_null.implement_core_ptr_non_null_NonNull_generic_par_T.new",
+      "file_index": 13,
+      "first_line": 218,
+      "local": true
+    },
+    {
+      "name": "core.ptr.mut_ptr.implement.is_null",
+      "file_index": 12,
+      "first_line": 35,
+      "local": true
+    },
+    {
+      "name": "core.ptr.non_null.implement_core_ptr_non_null_NonNull_generic_par_T.new_unchecked",
+      "file_index": 13,
+      "first_line": 196,
+      "local": true
+    },
+    {
+      "name": "core.ptr.non_null.implement_core_ptr_non_null_NonNull_slice_generic_par_T.slice_from_raw_parts",
+      "file_index": 13,
+      "first_line": 487,
+      "local": true
+    },
+    {
+      "name": "core.ptr.non_null.implement_core_ptr_non_null_NonNull_generic_par_T.as_ptr",
+      "file_index": 13,
+      "first_line": 330,
+      "local": true
+    },
+    {
+      "name": "core.ptr.non_null.implement_core_ptr_non_null_NonNull_slice_generic_par_T.as_non_null_ptr",
+      "file_index": 13,
+      "first_line": 531,
+      "local": true
+    },
+    {
+      "name": "core.ptr.mut_ptr.implement_pointer_mut_slice_generic_par_T.as_mut_ptr",
+      "file_index": 12,
+      "first_line": 1471,
+      "local": true
+    },
+    {
+      "name": "core.ptr.non_null.implement_core_ptr_non_null_NonNull_slice_generic_par_T.as_mut_ptr",
+      "file_index": 13,
+      "first_line": 551,
+      "local": true
+    },
+    {
+      "name": "core.ptr.unique.implement_core_ptr_unique_Unique_generic_par_T.new_unchecked",
+      "file_index": 14,
+      "first_line": 85,
+      "local": true
+    },
+    {
+      "name": "core.ptr.unique.implement_core_ptr_unique_Unique_generic_par_T.as_ptr",
+      "file_index": 14,
+      "first_line": 103,
+      "local": true
+    },
+    {
+      "name": "core.ptr.unique.implement_core_ptr_unique_Unique_generic_par_T.from",
+      "file_index": 14,
+      "first_line": 179,
+      "local": true
+    },
+    {
+      "name": "core.ptr.unique.implement_core_ptr_unique_Unique_generic_par_T.from",
+      "file_index": 14,
+      "first_line": 190,
+      "local": true
+    },
+    {
+      "name": "core.ptr.non_null.implement_core_ptr_non_null_NonNull_generic_par_T.from",
+      "file_index": 13,
+      "first_line": 783,
+      "local": true
+    },
+    {
+      "name": "core.ptr.const_ptr.implement.is_null",
+      "file_index": 11,
+      "first_line": 36,
+      "local": true
+    },
+    {
+      "name": "core.ptr.const_ptr.implement.guaranteed_eq",
+      "file_index": 11,
+      "first_line": 715,
+      "local": true
+    },
+    {
+      "name": "core.intrinsics.foreign_1.ptr_guaranteed_eq",
+      "file_index": 15,
+      "first_line": 1918,
+      "local": false
+    },
+    {
+      "name": "core.ptr.const_ptr.implement.add",
+      "file_index": 11,
+      "first_line": 808,
+      "local": true
+    },
+    {
+      "name": "core.ptr.const_ptr.implement.offset",
+      "file_index": 11,
+      "first_line": 450,
+      "local": true
+    },
+    {
+      "name": "core.ptr.const_ptr.implement.wrapping_add",
+      "file_index": 11,
+      "first_line": 935,
+      "local": true
+    },
+    {
+      "name": "core.ptr.const_ptr.implement.wrapping_offset",
+      "file_index": 11,
+      "first_line": 512,
+      "local": true
+    },
+    {
+      "name": "core.ptr.mut_ptr.implement.guaranteed_eq",
+      "file_index": 12,
+      "first_line": 660,
+      "local": true
+    },
+    {
+      "name": "core.result.implement_core_result_Result_generic_par_T_generic_par_F.from_residual",
+      "file_index": 16,
+      "first_line": 2103,
+      "local": true
+    },
+    {
+      "name": "core.convert.implement_generic_par_T.from",
+      "file_index": 17,
+      "first_line": 559,
+      "local": true
+    },
+    {
+      "name": "core.fmt.implement_core_fmt_ArgumentV1.new",
+      "file_index": 2,
+      "first_line": 327,
+      "local": true
+    },
+    {
+      "name": "core.slice.iter.implement_core_slice_iter_Iter_generic_par_T.new",
+      "file_index": 18,
+      "first_line": 88,
+      "local": true
+    },
+    {
+      "name": "core.slice.implement.as_ptr",
+      "file_index": 3,
+      "first_line": 476,
+      "local": true
+    },
+    {
+      "name": "core.intrinsics.foreign_1.assume",
+      "file_index": 15,
+      "first_line": 749,
+      "local": false
+    },
+    {
+      "name": "core.mem.size_of",
+      "file_index": 19,
+      "first_line": 310,
+      "local": true
+    },
+    {
+      "name": "core.slice.iter.implement_core_slice_iter_Iter_generic_par_T.post_inc_start",
+      "file_index": 4,
+      "first_line": 85,
+      "local": true
+    },
+    {
+      "name": "core.ptr.mut_ptr.implement.offset",
+      "file_index": 12,
+      "first_line": 460,
+      "local": true
+    },
+    {
+      "name": "core.slice.raw.from_raw_parts",
+      "file_index": 20,
+      "first_line": 90,
+      "local": true
+    },
+    {
+      "name": "core.alloc.layout.implement.from_size_align_unchecked",
+      "file_index": 21,
+      "first_line": 98,
+      "local": true
+    },
+    {
+      "name": "core.mem.valid_align.implement.new_unchecked",
+      "file_index": 7,
+      "first_line": 28,
+      "local": false
+    },
+    {
+      "name": "core.alloc.layout.implement.dangling",
+      "file_index": 21,
+      "first_line": 194,
+      "local": true
+    },
+    {
+      "name": "core.alloc.layout.implement.align",
+      "file_index": 21,
+      "first_line": 118,
+      "local": false
+    },
+    {
+      "name": "alloc.slice.implement.into_vec",
+      "file_index": 22,
+      "first_line": 526,
+      "local": true
+    },
+    {
+      "name": "alloc.alloc.exchange_malloc",
+      "file_index": 23,
+      "first_line": 318,
+      "local": false
+    },
+    {
+      "name": "alloc.raw_vec.implement_alloc_raw_vec_RawVec_generic_par_T_generic_par_A.from_raw_parts_in",
+      "file_index": 24,
+      "first_line": 215,
+      "local": true
+    },
+    {
+      "name": "alloc.raw_vec.implement_alloc_raw_vec_RawVec_generic_par_T_generic_par_A.ptr",
+      "file_index": 24,
+      "first_line": 223,
+      "local": true
+    },
+    {
+      "name": "alloc.alloc.alloc",
+      "file_index": 23,
+      "first_line": 88,
+      "local": true
+    },
+    {
+      "name": "core.alloc.layout.implement.size",
+      "file_index": 21,
+      "first_line": 108,
+      "local": false
+    },
+    {
+      "name": "alloc.alloc.alloc_zeroed",
+      "file_index": 23,
+      "first_line": 159,
+      "local": true
+    },
+    {
+      "name": "alloc.alloc.implement_alloc_alloc_Global.allocate",
+      "file_index": 23,
+      "first_line": 230,
+      "local": true
+    },
+    {
+      "name": "alloc.alloc.implement.alloc_impl",
+      "file_index": 23,
+      "first_line": 166,
+      "local": false
+    },
+    {
+      "name": "alloc.boxed.implement_alloc_boxed_Box_generic_par_T_generic_par_A.into_raw_with_allocator",
+      "file_index": 25,
+      "first_line": 1079,
+      "local": true
+    },
+    {
+      "name": "alloc.boxed.implement_alloc_boxed_Box_generic_par_T_generic_par_A.into_unique",
+      "file_index": 25,
+      "first_line": 1092,
+      "local": true
+    },
+    {
+      "name": "core.ptr.read",
+      "file_index": 9,
+      "first_line": 1080,
+      "local": true
+    },
+    {
+      "name": "alloc.boxed.implement_alloc_boxed_Box_generic_par_T_generic_par_A.leak",
+      "file_index": 25,
+      "first_line": 1152,
+      "local": true
+    },
+    {
+      "name": "alloc.boxed.implement_alloc_boxed_Box_generic_par_T_generic_par_A.drop",
+      "file_index": 25,
+      "first_line": 1179,
+      "local": true
+    },
+    {
+      "name": "core.mem.manually_drop.implement.new",
+      "file_index": 26,
+      "first_line": 70,
+      "local": true
+    },
+    {
+      "name": "core.mem.manually_drop.implement_core_mem_manually_drop_ManuallyDrop_generic_par_T.deref",
+      "file_index": 26,
+      "first_line": 153,
+      "local": true
+    },
+    {
+      "name": "alloc.slice.hack.into_vec",
+      "file_index": 22,
+      "first_line": 165,
+      "local": true
+    },
+    {
+      "name": "core.slice.implement.len",
+      "file_index": 3,
+      "first_line": 129,
+      "local": true
+    },
+    {
+      "name": "alloc.vec.implement_alloc_vec_Vec_generic_par_T_generic_par_A.from_raw_parts_in",
+      "file_index": 5,
+      "first_line": 690,
+      "local": true
+    },
+    {
+      "name": "alloc.vec.implement_alloc_vec_Vec_generic_par_T_generic_par_A.as_ptr",
+      "file_index": 5,
+      "first_line": 1137,
+      "local": true
+    },
+    {
+      "name": "alloc.vec.implement_alloc_vec_Vec_generic_par_T_generic_par_A.as_mut_ptr",
+      "file_index": 5,
+      "first_line": 1173,
+      "local": true
+    },
+    {
+      "name": "core.ptr.drop_in_place",
+      "file_index": 9,
+      "first_line": 486,
+      "local": true
+    }
   ],
   "calls": [
     [
@@ -648,420 +822,420 @@ commit;
       13
     ],
     [
-      1,
+      7,
       39,
       18,
       14,
       15
     ],
     [
-      2,
+      9,
       511,
       5,
       16,
       17
     ],
     [
-      2,
+      9,
       531,
       5,
       18,
       19
     ],
     [
-      2,
+      9,
       684,
       5,
       20,
       21
     ],
     [
-      2,
+      9,
       684,
       20,
       20,
       22
     ],
     [
-      2,
+      9,
       716,
       5,
       23,
       24
     ],
     [
-      2,
+      9,
       716,
       24,
       23,
       25
     ],
     [
-      3,
+      13,
       219,
       13,
       26,
       27
     ],
     [
-      3,
+      13,
       221,
       27,
       26,
       28
     ],
     [
-      3,
+      13,
       489,
       18,
       29,
       28
     ],
     [
-      3,
+      13,
       489,
       38,
       29,
       23
     ],
     [
-      3,
+      13,
       489,
       70,
       29,
       30
     ],
     [
-      3,
+      13,
       533,
       18,
       31,
       28
     ],
     [
-      3,
+      13,
       533,
       41,
       31,
       30
     ],
     [
-      3,
+      13,
       533,
       41,
       31,
       32
     ],
     [
-      3,
+      13,
       552,
       9,
       33,
       31
     ],
     [
-      3,
+      13,
       552,
       9,
       33,
       30
     ],
     [
-      4,
+      14,
       87,
       36,
       34,
       28
     ],
     [
-      4,
+      14,
       104,
       9,
       35,
       30
     ],
     [
-      4,
+      14,
       180,
       9,
       36,
       37
     ],
     [
-      4,
+      14,
       180,
       20,
       36,
       38
     ],
     [
-      5,
+      11,
       39,
       9,
       39,
       40
     ],
     [
-      5,
+      11,
       39,
       43,
       39,
       16
     ],
     [
-      5,
+      11,
       719,
       9,
       40,
       41
     ],
     [
-      5,
+      11,
       813,
       18,
       42,
       43
     ],
     [
-      5,
+      11,
       939,
       9,
       44,
       45
     ],
     [
-      6,
+      12,
       38,
       9,
       27,
       46
     ],
     [
-      6,
+      12,
       38,
       41,
       27,
       18
     ],
     [
-      6,
+      12,
       664,
       9,
       46,
       41
     ],
     [
-      7,
+      2,
       390,
       13,
       13,
       13
     ],
     [
-      8,
+      16,
       2105,
       27,
       47,
       48
     ],
     [
-      7,
+      2,
       339,
       5,
       3,
       49
     ],
     [
-      9,
+      3,
       733,
       9,
       6,
       50
     ],
     [
-      10,
+      18,
       89,
       19,
       50,
       51
     ],
     [
-      10,
+      18,
       92,
       13,
       50,
       52
     ],
     [
-      10,
+      18,
       92,
       21,
       50,
       39
     ],
     [
-      10,
+      18,
       94,
       26,
       50,
       53
     ],
     [
-      10,
+      18,
       95,
       17,
       50,
       44
     ],
     [
-      10,
+      18,
       97,
       17,
       50,
       42
     ],
     [
-      10,
+      18,
       100,
       25,
       50,
       28
     ],
     [
-      10,
+      18,
       135,
       1,
       7,
       30
     ],
     [
-      10,
+      18,
       135,
       1,
       7,
       54
     ],
     [
-      10,
+      18,
       135,
       1,
       54,
       45
     ],
     [
-      10,
+      18,
       135,
       1,
       54,
       53
     ],
     [
-      10,
+      18,
       135,
       1,
       54,
       30
     ],
     [
-      10,
+      18,
       135,
       1,
       54,
       30
     ],
     [
-      10,
+      18,
       135,
       1,
       54,
       28
     ],
     [
-      10,
+      18,
       135,
       1,
       54,
       30
     ],
     [
-      10,
+      18,
       135,
       1,
       54,
       55
     ],
     [
-      10,
+      18,
       135,
       1,
       7,
       52
     ],
     [
-      10,
+      18,
       135,
       1,
       7,
       30
     ],
     [
-      10,
+      18,
       135,
       1,
       7,
       27
     ],
     [
-      10,
+      18,
       135,
       1,
       7,
       53
     ],
     [
-      10,
+      18,
       135,
       1,
       7,
       52
     ],
     [
-      10,
+      18,
       135,
       1,
       7,
       39
     ],
     [
-      11,
+      20,
       97,
       11,
       56,
       20
     ],
     [
-      12,
+      21,
       100,
       40,
       57,
       58
     ],
     [
-      12,
+      21,
       196,
       18,
       59,
       28
     ],
     [
-      12,
+      21,
       196,
       41,
       59,
       19
     ],
     [
-      12,
+      21,
       196,
       71,
       59,
@@ -1082,236 +1256,235 @@ commit;
       62
     ],
     [
-      13,
+      24,
       216,
       30,
       63,
       34
     ],
     [
-      13,
+      24,
       224,
       9,
       64,
       35
     ],
     [
-      14,
+      23,
       89,
       27,
       65,
       66
     ],
     [
-      14,
+      23,
       89,
       42,
       65,
       60
     ],
     [
-      14,
+      23,
       160,
       34,
       67,
       66
     ],
     [
-      14,
+      23,
       160,
       49,
       67,
       60
     ],
     [
-      14,
+      23,
       231,
       9,
       68,
       69
     ],
     [
-      15,
+      25,
       1080,
       31,
       70,
       71
     ],
     [
-      15,
+      25,
       1081,
       10,
       70,
       35
     ],
     [
-      15,
+      25,
       1098,
       30,
       71,
       72
     ],
     [
-      15,
+      25,
       1099,
       10,
       71,
       36
     ],
     [
-      15,
+      25,
       1099,
       23,
       71,
       73
     ],
     [
-      15,
+      25,
       1100,
       5,
       71,
       74
     ],
     [
-      15,
+      25,
       1156,
       24,
       73,
       75
     ],
     [
-      15,
+      25,
       1156,
       24,
       73,
       76
     ],
     [
-      15,
+      25,
       1156,
       24,
       73,
       35
     ],
     [
-      16,
+      22,
       167,
       23,
       77,
       78
     ],
     [
-      16,
+      22,
       168,
       30,
       77,
       70
     ],
     [
-      16,
+      22,
       169,
       13,
       77,
       79
     ],
     [
-      16,
+      22,
       171,
       5,
       77,
       74
     ],
     [
-      16,
+      22,
       528,
       9,
       61,
       77
     ],
     [
-      17,
+      5,
       691,
       29,
       79,
       63
     ],
     [
-      17,
+      5,
       1140,
       19,
       80,
       64
     ],
     [
-      17,
+      5,
       1142,
       13,
       80,
       52
     ],
     [
-      17,
+      5,
       1142,
       21,
       80,
       27
     ],
     [
-      17,
+      5,
       1176,
       19,
       81,
       64
     ],
     [
-      17,
+      5,
       1178,
       13,
       81,
       52
     ],
     [
-      17,
+      5,
       1178,
       21,
       81,
       27
     ],
     [
-      17,
+      5,
       2497,
       18,
       11,
       56
     ],
     [
-      17,
+      5,
       2497,
       40,
       11,
       80
     ],
     [
-      17,
+      5,
       2881,
       13,
       9,
       82
     ],
     [
-      17,
+      5,
       2881,
       32,
       9,
       23
     ],
     [
-      17,
+      5,
       2881,
       62,
       9,
       81
     ]
   ]
-}
-*/
+}*/


### PR DESCRIPTION
## Description

Add source location information to the call sites output to help locate function/method in source files, rather than just the source locations of the calls to them.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh
Ran it over non trivial project and sampled bits of the calls output and verified that such source locations exist and that the functions that claim to be there actually are there.