### PR TITLE
Assume symbolic reference is never null

### DIFF
--- a/checker/src/abstract_value.rs
+++ b/checker/src/abstract_value.rs
@@ -3829,6 +3829,13 @@ impl AbstractValueTrait for Rc<AbstractValue> {
             (Expression::CompileTimeConstant(ConstantDomain::False), _) => {
                 return other.clone();
             }
+            // [0 != ref] -> true
+            (
+                Expression::CompileTimeConstant(ConstantDomain::U128(0)),
+                Expression::Reference { .. },
+            ) => {
+                return Rc::new(TRUE);
+            }
             // [0 != (1 << x)] -> true (we can assume no overflows occur)
             (
                 Expression::CompileTimeConstant(ConstantDomain::U128(0)),


### PR DESCRIPTION
## Description

Symbolic reference to memory locations will never be null at runtime, so constant fold 0 != symref to True.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh

