### PR TITLE
Tweak and explain promotion of assert conditions.

### DIFF
--- a/checker/src/lib.rs
+++ b/checker/src/lib.rs
@@ -10,7 +10,7 @@
 // versions of Mirai will continue to work just as before.
 //
 // In the current world, however, we have to use the following hacky feature to get access to a
-// private and not very stable set of APIs from whatever compiler is in the path when we run Mirai.
+// private and not very stable set of APIs from whatever compiler is in the toolchain when we run Mirai.
 // While pretty bad, it is a lot less bad than having to write our own compiler, so here goes.
 #![feature(rustc_private)]
 #![feature(box_patterns)]


### PR DESCRIPTION
## Description

Extract the promotable part of an assert condition that is expected to be false, only after negating the condition. Doing it before is incorrect when extracting x from (x || y) when (x || y) is expected to be false. I.e. !x  does not => !(x || y).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] API change with a documentation update
- [ ] Additional test coverage
- [ ] Code cleanup or just keeping up with the latest Rustc nightly

## How Has This Been Tested?
./validate.sh